### PR TITLE
bugfix: Refresh the code stream length in time to avoid 1 byte less c…

### DIFF
--- a/src/codec/utils/EncodeStream.cpp
+++ b/src/codec/utils/EncodeStream.cpp
@@ -177,11 +177,11 @@ void EncodeStream::writeEncodedUint64(uint64_t value) {
       break;
     }
     bytes[_position++] = byte;
+    positionChanged(0);
     if (value == 0) {
       break;
     }
   }
-  positionChanged(0);
 }
 
 void EncodeStream::writeBits(int32_t value, uint8_t numBits) {


### PR DESCRIPTION
…opy length during memory expansion.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
